### PR TITLE
Fixed Example

### DIFF
--- a/example/config/models.js
+++ b/example/config/models.js
@@ -12,5 +12,6 @@ module.exports.models = {
   // i.e. the name of one of your app's connections (see `config/connections.js`)
   //
   // (defaults to localDiskDb)
-  connection: 'localDiskDb'
+  connection: 'localDiskDb',
+  migrate: 'drop'
 };

--- a/example/package.json
+++ b/example/package.json
@@ -5,8 +5,8 @@
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
-    "sails": "git://github.com/balderdashy/sails.git",
-    "sails-disk": "git://github.com/balderdashy/sails-disk.git",
+    "sails": "~0.10.5",
+    "sails-disk": "~0.10.4",
     "ejs": "~0.8.4",
     "grunt": "0.4.2",
     "grunt-sync": "~0.0.4",


### PR DESCRIPTION
The Example project was trying to load pre-release Sails directly from Github instead of a versioned release and it was failing.  

I also added models.migrate: 'drop' to the config because I figured that prompt dumped in between the incredibly verbose logged at boot was confusing to someone already not familiar with Sails.  

#37 